### PR TITLE
Implement category CRUD with DataTables

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Category;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class CategoryController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): View
+    {
+        $categories = Category::all();
+        return view('categories.index', compact('categories'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(): View
+    {
+        return view('categories.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'sortorder' => ['nullable', 'integer'],
+        ]);
+
+        Category::create($validated);
+
+        return redirect()->route('categories.index')
+            ->with('success', 'Category created successfully.');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Category $category): View
+    {
+        return view('categories.edit', compact('category'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Category $category): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'sortorder' => ['nullable', 'integer'],
+        ]);
+
+        $category->update($validated);
+
+        return redirect()->route('categories.index')
+            ->with('success', 'Category updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Category $category): RedirectResponse
+    {
+        $category->delete();
+
+        return redirect()->route('categories.index')
+            ->with('success', 'Category deleted successfully.');
+    }
+}

--- a/resources/views/categories/create.blade.php
+++ b/resources/views/categories/create.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('title', 'Create Category')
+
+@section('content')
+<h1 class="h3 mb-4 text-gray-800">Create Category</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+<form action="{{ route('categories.store') }}" method="POST">
+    @csrf
+    <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" name="name" class="form-control" value="{{ old('name') }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Sort Order</label>
+        <input type="number" name="sortorder" class="form-control" value="{{ old('sortorder') }}">
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="{{ route('categories.index') }}" class="btn btn-secondary">Cancel</a>
+</form>
+@endsection

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Category')
+
+@section('content')
+<h1 class="h3 mb-4 text-gray-800">Edit Category</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+<form action="{{ route('categories.update', $category) }}" method="POST">
+    @csrf
+    @method('PUT')
+    <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" name="name" class="form-control" value="{{ old('name', $category->name) }}" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Sort Order</label>
+        <input type="number" name="sortorder" class="form-control" value="{{ old('sortorder', $category->sortorder) }}">
+    </div>
+    <button type="submit" class="btn btn-primary">Update</button>
+    <a href="{{ route('categories.index') }}" class="btn btn-secondary">Cancel</a>
+</form>
+@endsection

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.app')
+
+@section('title', 'Categories')
+
+@section('content')
+<h1 class="h3 mb-4 text-gray-800">Categories</h1>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+<a href="{{ route('categories.create') }}" class="btn btn-primary mb-3">Create Category</a>
+<table class="table table-bordered" id="categories-table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Sort Order</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($categories as $category)
+        <tr>
+            <td>{{ $category->name }}</td>
+            <td>{{ $category->sortorder }}</td>
+            <td>
+                <a href="{{ route('categories.edit', $category) }}" class="btn btn-sm btn-warning">Edit</a>
+                <form action="{{ route('categories.destroy', $category) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this category?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection
+
+@push('styles')
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+@endpush
+
+@push('scripts')
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+<script>
+$(document).ready(function() {
+    $('#categories-table').DataTable();
+});
+</script>
+@endpush

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,6 +11,7 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
     <!-- SB Admin 2 theme -->
     <link href="https://cdn.jsdelivr.net/npm/startbootstrap-sb-admin-2@4.1.4/css/sb-admin-2.min.css" rel="stylesheet">
+    @stack('styles')
 </head>
 <body id="page-top">
 <div id="wrapper">
@@ -26,6 +27,13 @@
             <a class="nav-link" href="{{ url('/dashboard') }}">
                 <i class="fas fa-fw fa-tachometer-alt"></i>
                 <span>Dashboard</span>
+            </a>
+        </li>
+        <!-- Nav Item - Categories -->
+        <li class="nav-item">
+            <a class="nav-link" href="{{ route('categories.index') }}">
+                <i class="fas fa-fw fa-list"></i>
+                <span>Categories</span>
             </a>
         </li>
     </ul>
@@ -65,5 +73,6 @@
 <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/startbootstrap-sb-admin-2@4.1.4/js/sb-admin-2.min.js"></script>
+@stack('scripts')
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\CategoryController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -9,3 +10,5 @@ Route::get('/', function () {
 Route::get('/dashboard', function () {
     return view('dashboard');
 });
+
+Route::resource('categories', CategoryController::class);


### PR DESCRIPTION
## Summary
- Add `CategoryController` with full CRUD actions
- Introduce category views including DataTables listing, create, and edit forms
- Hook category routes and navigation into application layout with script/style stacks

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/firstgpt/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_689ab329dbe883339f7e09bc639ac181