### PR TITLE
Add Tag model and CRUD interface

### DIFF
--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tag;
+use Illuminate\Http\Request;
+
+class TagController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $tags = Tag::all();
+        return view('tags.index', compact('tags'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('tags.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+        ]);
+
+        Tag::create($data);
+
+        return redirect()->route('tags.index');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Tag $tag)
+    {
+        return view('tags.show', compact('tag'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Tag $tag)
+    {
+        return view('tags.edit', compact('tag'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Tag $tag)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+        ]);
+
+        $tag->update($data);
+
+        return redirect()->route('tags.index');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Tag $tag)
+    {
+        $tag->delete();
+
+        return redirect()->route('tags.index');
+    }
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    use HasFactory, HasUuids;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/database/migrations/2024_01_01_000004_create_tags_table.php
+++ b/database/migrations/2024_01_01_000004_create_tags_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tags');
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -28,6 +28,12 @@
                 <span>Dashboard</span>
             </a>
         </li>
+        <li class="nav-item">
+            <a class="nav-link" href="{{ route('tags.index') }}">
+                <i class="fas fa-fw fa-tags"></i>
+                <span>Tags</span>
+            </a>
+        </li>
     </ul>
     <!-- End of Sidebar -->
 

--- a/resources/views/tags/create.blade.php
+++ b/resources/views/tags/create.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('title', 'Create Tag')
+
+@section('content')
+    <h1 class="h3 mb-4">Create Tag</h1>
+
+    <form method="POST" action="{{ route('tags.store') }}">
+        @csrf
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input type="text" name="name" class="form-control" required>
+        </div>
+        <button class="btn btn-primary">Save</button>
+        <a href="{{ route('tags.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+@endsection

--- a/resources/views/tags/edit.blade.php
+++ b/resources/views/tags/edit.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Tag')
+
+@section('content')
+    <h1 class="h3 mb-4">Edit Tag</h1>
+
+    <form method="POST" action="{{ route('tags.update', $tag) }}">
+        @csrf
+        @method('PUT')
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input type="text" name="name" class="form-control" value="{{ $tag->name }}" required>
+        </div>
+        <button class="btn btn-primary">Update</button>
+        <a href="{{ route('tags.index') }}" class="btn btn-secondary">Cancel</a>
+    </form>
+@endsection

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -1,0 +1,34 @@
+@extends('layouts.app')
+
+@section('title', 'Tags')
+
+@section('content')
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h3">Tags</h1>
+        <a href="{{ route('tags.create') }}" class="btn btn-primary">New Tag</a>
+    </div>
+
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th style="width: 150px;">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($tags as $tag)
+                <tr>
+                    <td>{{ $tag->name }}</td>
+                    <td>
+                        <a href="{{ route('tags.edit', $tag) }}" class="btn btn-sm btn-secondary">Edit</a>
+                        <form action="{{ route('tags.destroy', $tag) }}" method="POST" class="d-inline">
+                            @csrf
+                            @method('DELETE')
+                            <button class="btn btn-sm btn-danger" onclick="return confirm('Are you sure?')">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+@endsection

--- a/resources/views/tags/show.blade.php
+++ b/resources/views/tags/show.blade.php
@@ -1,0 +1,11 @@
+@extends('layouts.app')
+
+@section('title', 'Tag Detail')
+
+@section('content')
+    <h1 class="h3 mb-4">Tag Detail</h1>
+
+    <p><strong>Name:</strong> {{ $tag->name }}</p>
+
+    <a href="{{ route('tags.index') }}" class="btn btn-secondary">Back</a>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\TagController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -9,3 +10,5 @@ Route::get('/', function () {
 Route::get('/dashboard', function () {
     return view('dashboard');
 });
+
+Route::resource('tags', TagController::class);


### PR DESCRIPTION
## Summary
- add `tags` table migration with UUID id and name
- create Tag model, controller, routes and blade views for CRUD
- link Tags section in sidebar navigation

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/firstgpt/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689ab37aca9883339b50eb39b12aa149